### PR TITLE
Rename bKash payment initiation function

### DIFF
--- a/bkash-payment.js
+++ b/bkash-payment.js
@@ -1,4 +1,4 @@
-function initiateBkashPayment() {
+function initiateBKashPayment() {
     // Example bKash Payment API URL
     var bkashApiUrl = "https://checkout.sandbox.bka.sh/v1.2.0-beta/checkout/payment/create";
 

--- a/bkash.js
+++ b/bkash.js
@@ -1,6 +1,6 @@
 // bkash.js
 
-function initiateBkashPayment(amount, invoice) {
+function initiateBKashPayment(amount, invoice) {
   // Replace with your bKash API details
   const bkashEndpoint = "YOUR_BKASH_API_ENDPOINT";
   const bkashMerchantId = "YOUR_MERCHANT_ID";


### PR DESCRIPTION
## Summary
- Rename payment initiation helper to `initiateBKashPayment` to match bKash capitalization.
- Align secondary payment script with same function name.

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `npm run lint` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68aee75f5790832f8b9ce32a2e2ecbeb