### PR TITLE
feat: add multi-step payment popup

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -77,7 +77,9 @@ body {
   cursor: pointer;
 }
 
-.popup-actions button.proceed {
+
+.popup-actions button.next,
+.popup-actions button.confirm {
   background: #fff;
   color: #e2136e;
   margin-right: 10px;
@@ -93,4 +95,12 @@ body {
   text-align: center;
   margin-top: 20px;
   font-size: 0.75em;
+}
+
+.popup-step {
+  margin-top: 15px;
+}
+
+.hidden {
+  display: none;
 }

--- a/popup.html
+++ b/popup.html
@@ -12,26 +12,58 @@
       <span class="logo">bKash</span>
       <span class="title">Payment</span>
     </div>
+
     <div class="popup-details">
       <p><strong>Merchant :</strong> BDSHOP.COM</p>
       <p><strong>Invoice no :</strong> 21279615</p>
       <p><strong>Amount :</strong> BDT 5</p>
     </div>
-    <div class="popup-form">
-      <label for="bkash-number">Your bKash account number</label>
-      <input id="bkash-number" type="text" placeholder="e.g 01XXXXXXXXX" />
-      <div class="terms">
-        <input type="checkbox" id="agree" />
-        <label for="agree">I agree to the <a href="#">terms and conditions</a></label>
+
+    <!-- Step 1: Enter bKash number -->
+    <div class="popup-step step-1">
+      <div class="popup-form">
+        <label for="bkash-number">Your bKash account number</label>
+        <input id="bkash-number" type="text" placeholder="e.g 01XXXXXXXXX" />
+        <div class="terms">
+          <input type="checkbox" id="agree" />
+          <label for="agree">I agree to the <a href="#">terms and conditions</a></label>
+        </div>
+      </div>
+      <div class="popup-actions">
+        <button class="next" data-next="2">NEXT</button>
+        <button class="close">CLOSE</button>
       </div>
     </div>
-    <div class="popup-actions">
-      <button class="proceed">PROCEED</button>
-      <button class="close">CLOSE</button>
+
+    <!-- Step 2: Verification code -->
+    <div class="popup-step step-2 hidden">
+      <div class="popup-form">
+        <label for="verification-code">Verification Code</label>
+        <input id="verification-code" type="text" placeholder="Enter code" />
+      </div>
+      <div class="popup-actions">
+        <button class="next" data-next="3">NEXT</button>
+        <button class="close">CLOSE</button>
+      </div>
     </div>
+
+    <!-- Step 3: Confirm with PIN -->
+    <div class="popup-step step-3 hidden">
+      <div class="popup-form">
+        <label for="pin">Enter PIN</label>
+        <input id="pin" type="password" placeholder="****" />
+      </div>
+      <div class="popup-actions">
+        <button class="confirm">CONFIRM</button>
+        <button class="close">CLOSE</button>
+      </div>
+    </div>
+
     <div class="popup-footer">
       16247
     </div>
   </div>
-</body>
+
+  <script src="popup.js"></script>
+  </body>
 </html>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,31 @@
+// Handles the multi-step payment popup interactions
+
+document.querySelectorAll('.next').forEach((btn) => {
+  btn.addEventListener('click', () => {
+    const currentStep = btn.closest('.popup-step');
+    const nextStepNum = btn.dataset.next;
+    if (currentStep && nextStepNum) {
+      currentStep.classList.add('hidden');
+      const nextStep = document.querySelector('.step-' + nextStepNum);
+      if (nextStep) {
+        nextStep.classList.remove('hidden');
+      }
+    }
+  });
+});
+
+const confirmBtn = document.querySelector('.confirm');
+if (confirmBtn) {
+  confirmBtn.addEventListener('click', () => {
+    // Placeholder confirmation action
+    alert('Payment confirmed!');
+  });
+}
+
+document.querySelectorAll('.close').forEach((btn) => {
+  btn.addEventListener('click', () => {
+    if (typeof window !== 'undefined' && window.close) {
+      window.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- redesign payment popup to include three sequential steps
- add styles for step navigation and hide/show handling
- implement simple JS to progress through steps and finalize payment

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68aff8a46b18832fb892f7670471243d